### PR TITLE
Show fixed findings in weekly digest

### DIFF
--- a/_build/files/opt/vulcan-reports-generator/generators/livereport/resources/template
+++ b/_build/files/opt/vulcan-reports-generator/generators/livereport/resources/template
@@ -43,15 +43,11 @@ You can see the full list of FIXED vulnerabilities <a href="{{ .LinkToLiveReport
         <b>FIXED Vulnerabilities</b><br/>
         <i>{{ .StartDate }} - {{ .EndDate }}</i>
     </td>
-    <td style="border:1px solid black;padding:15px">
-        <b>Total</b>
-    </td>
 </tr>
-{{ range .FixedSeverities }}
+{{ range .FixedFindings }}
     <tr style="border:1px solid black">
         <td style="border:1px solid black;padding:15px">{{ .Description }} </td>
-        <td style="border:1px solid black;padding:15px;text-align:right;color:red">{{ .NewFindings }}</td>
-        <td style="border:1px solid black;padding:15px;text-align:right;">{{ .TotalFindings }}</td>
+        <td style="border:1px solid black;padding:15px;text-align:right;color:red">{{ .TotalFixed }}</td>
     </tr>
 {{ end }}
 </table><br>

--- a/_build/files/opt/vulcan-reports-generator/generators/livereport/resources/template
+++ b/_build/files/opt/vulcan-reports-generator/generators/livereport/resources/template
@@ -28,5 +28,34 @@ For detailed information about vulnerabilities, affected assets and suggested ac
     </tr>
 {{ end }}
 </table><br>
+
+<hr/>
+<h3>Fixed vulnerabilities between {{ .StartDate }} and {{ .EndDate }}</h3>
+<br/>
+You can see the full list of FIXED vulnerabilities <a href="{{ .LinkToLiveReport }}">in the Vulcan Live Report</a></div>.
+<br/><br/>
+<table style="border:1px solid black;border-collapse:collapse">
+<tr style="border:1px solid black">
+    <td style="border:1px solid black;padding:15px">
+        <b>Severity</b>
+    </td>
+    <td style="border:1px solid black;padding:15px">
+        <b>FIXED Vulnerabilities</b><br/>
+        <i>{{ .StartDate }} - {{ .EndDate }}</i>
+    </td>
+    <td style="border:1px solid black;padding:15px">
+        <b>Total</b>
+    </td>
+</tr>
+{{ range .FixedSeverities }}
+    <tr style="border:1px solid black">
+        <td style="border:1px solid black;padding:15px">{{ .Description }} </td>
+        <td style="border:1px solid black;padding:15px;text-align:right;color:red">{{ .NewFindings }}</td>
+        <td style="border:1px solid black;padding:15px;text-align:right;">{{ .TotalFindings }}</td>
+    </tr>
+{{ end }}
+</table><br>
+
+
 <i>Copyright © 2020 Adevinta, All rights reserved.<br/>
 You are receiving this email because you signed up for the Adevinta Security Overview.</i>

--- a/_build/files/opt/vulcan-reports-generator/generators/livereport/resources/template
+++ b/_build/files/opt/vulcan-reports-generator/generators/livereport/resources/template
@@ -32,8 +32,6 @@ For detailed information about vulnerabilities, affected assets and suggested ac
 <hr/>
 <h3>Fixed vulnerabilities between {{ .StartDate }} and {{ .EndDate }}</h3>
 <br/>
-You can see the full list of FIXED vulnerabilities <a href="{{ .LinkToLiveReport }}">in the Vulcan Live Report</a></div>.
-<br/><br/>
 <table style="border:1px solid black;border-collapse:collapse">
 <tr style="border:1px solid black">
     <td style="border:1px solid black;padding:15px">
@@ -47,7 +45,7 @@ You can see the full list of FIXED vulnerabilities <a href="{{ .LinkToLiveReport
 {{ range .FixedFindings }}
     <tr style="border:1px solid black">
         <td style="border:1px solid black;padding:15px">{{ .Description }} </td>
-        <td style="border:1px solid black;padding:15px;text-align:right;color:red">{{ .TotalFixed }}</td>
+        <td style="border:1px solid black;padding:15px;text-align:right;color:green">{{ .TotalFixed }}</td>
     </tr>
 {{ end }}
 </table><br>

--- a/pkg/report/livereport_generator.go
+++ b/pkg/report/livereport_generator.go
@@ -30,20 +30,25 @@ type liveReportGeneratorCfg struct {
 // data supplied in the generation
 // request for a live report.
 type liveReportRequest struct {
-	TeamID       string `mapstructure:"team_id"`
-	Info         int    `mapstructure:"info"`
-	Low          int    `mapstructure:"low"`
-	Medium       int    `mapstructure:"medium"`
-	High         int    `mapstructure:"high"`
-	Critical     int    `mapstructure:"critical"`
-	InfoDiff     int    `mapstructure:"info_diff"`
-	LowDiff      int    `mapstructure:"low_diff"`
-	MediumDiff   int    `mapstructure:"medium_diff"`
-	HighDiff     int    `mapstructure:"high_diff"`
-	CriticalDiff int    `mapstructure:"critical_diff"`
-	DateFrom     string `mapstructure:"date_from"`
-	DateTo       string `mapstructure:"date_to"`
-	URL          string `mapstructure:"live_report_url"`
+	TeamID        string `mapstructure:"team_id"`
+	Info          int    `mapstructure:"info"`
+	Low           int    `mapstructure:"low"`
+	Medium        int    `mapstructure:"medium"`
+	High          int    `mapstructure:"high"`
+	Critical      int    `mapstructure:"critical"`
+	InfoDiff      int    `mapstructure:"info_diff"`
+	LowDiff       int    `mapstructure:"low_diff"`
+	MediumDiff    int    `mapstructure:"medium_diff"`
+	HighDiff      int    `mapstructure:"high_diff"`
+	CriticalDiff  int    `mapstructure:"critical_diff"`
+	InfoFixed     int    `mapstructure:"info_fixed"`
+	LowFixed      int    `mapstructure:"low_fixed"`
+	MediumFixed   int    `mapstructure:"medium_fixed"`
+	HighFixed     int    `mapstructure:"high_fixed"`
+	CriticalFixed int    `mapstructure:"critical_fixed"`
+	DateFrom      string `mapstructure:"date_from"`
+	DateTo        string `mapstructure:"date_to"`
+	URL           string `mapstructure:"live_report_url"`
 }
 
 type liveReportData struct {
@@ -107,11 +112,16 @@ func (g *liveReportGenerator) Print(teamInfo teamInfo, liveReportReq liveReportR
 		TotalFindings int
 		NewFindings   int
 	}
+	type FixedFinding struct {
+		Description string
+		TotalFixed  int
+	}
 	type Report struct {
 		StartDate        string
 		EndDate          string
 		LinkToLiveReport string
 		Severities       []Severity
+		FixedFindings    []FixedFinding
 	}
 
 	r := Report{
@@ -124,6 +134,13 @@ func (g *liveReportGenerator) Print(teamInfo teamInfo, liveReportReq liveReportR
 			{Description: "Medium", TotalFindings: liveReportReq.Medium, NewFindings: liveReportReq.MediumDiff},
 			{Description: "Low", TotalFindings: liveReportReq.Low, NewFindings: liveReportReq.LowDiff},
 			{Description: "Informational", TotalFindings: liveReportReq.Info, NewFindings: liveReportReq.InfoDiff},
+		},
+		FixedFindings: []FixedFinding{
+			{Description: "Critical", TotalFixed: liveReportReq.CriticalFixed},
+			{Description: "High", TotalFixed: liveReportReq.HighFixed},
+			{Description: "Medium", TotalFixed: liveReportReq.MediumFixed},
+			{Description: "Low", TotalFixed: liveReportReq.LowFixed},
+			{Description: "Informational", TotalFixed: liveReportReq.InfoFixed},
 		},
 	}
 


### PR DESCRIPTION
This PR includes a new section in the Weekly Digest, showing the number of fixed issues during the last week.

![image](https://user-images.githubusercontent.com/1558179/114359946-c5aea200-9b74-11eb-81c6-74538c7eb236.png)
