### PR TITLE
Upgrade Flyway

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ dist: bionic
 language: go
 env:
   global:
-    - FLYWAY_VERSION=9.1.4
-    - INPUT_BUILDARGS=FLYWAY_VERSION=9.1.4
+    - FLYWAY_VERSION=9.4.0
+    - INPUT_BUILDARGS=FLYWAY_VERSION=$FLYWAY_VERSION
 go:
   - 1.18.x
 go_import_path: github.com/adevinta/vulcan-reports-generator

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add postgresql-client
 # add flyway
 RUN apk add --no-cache --update openjdk8-jre-base bash gettext libc6-compat
 
-ARG FLYWAY_VERSION=9.1.4
+ARG FLYWAY_VERSION=9.4.0
 
 RUN wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz \
     && tar -xzf flyway-commandline-${FLYWAY_VERSION}.tar.gz --strip 1 \


### PR DESCRIPTION
This PR upgrades Flyway to v9.4.0 in order to fix some associated vulnerabilities present in dependencies:
- org.apache.commons:commons-text:1.9
- com.fasterxml.jackson.core:jackson-databind:2.13.2.1

