### PR TITLE
Update Flyway version to fix vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: bionic
 language: go
 env:
   global:
-    - FLYWAY_VERSION=9.4.0
+    - FLYWAY_VERSION=9.5.0
     - INPUT_BUILDARGS=FLYWAY_VERSION=$FLYWAY_VERSION
 go:
   - 1.19.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: bionic
 language: go
 env:
   global:
-    - FLYWAY_VERSION=9.5.0
+    - FLYWAY_VERSION=9.5.1
     - INPUT_BUILDARGS=FLYWAY_VERSION=$FLYWAY_VERSION
 go:
   - 1.19.x


### PR DESCRIPTION
**Flyway 9.5.0 (2022-10-19)**
**Changes**

- Ensure correct version of SQL Fluff is installed
- Update version of 'commons-text' to fix vulnerability **CVE-2022-42889**
- Add edition to the version model
- When urls are unsupported by check, ascertain which ones are unsupported, and include them as part of the exception.

**Flyway 9.5.1 (2022-10-20)**
**Database compatibility**

- Remove in-product warnings when using PostgreSQL 15